### PR TITLE
Generate code fot http handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ Generate code to instrument an interface.
 
 ## Supported Interfaces
 
-At the moment only methods of interfaces can be instrumented that return an error as the last return value.
+### Binary
+
+An interface with methods that return an error as the last return value.
 Depending if the error is nil, the corresponding counter vector will be increased.
+
+### Handler
+
+An interface with methods that have no return values, the first argument is an `http.ResponseWriter` and the second argument is an `*http.Request`.
 
 ## Install
 

--- a/examples/http-handler/gen.go
+++ b/examples/http-handler/gen.go
@@ -1,0 +1,63 @@
+// This code in auto generated. DO NOT EDIT.
+
+package httphandler
+
+import (
+	"net/http"
+
+	"github.com/leonnicolas/genstrument/examples/pkg"
+	"github.com/metalmatze/signal/server/signalhttp"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type InstrumentedServer struct {
+	Server
+	signalhttp.HandlerInstrumenter
+}
+
+func NewInstrumentedServer(impl Server, r prometheus.Registerer) *InstrumentedServer {
+	i := signalhttp.NewHandlerInstrumenter(r, []string{"handler"})
+	return &InstrumentedServer{impl, i}
+}
+
+func (i *InstrumentedServer) ExternalTypeParam(w http.ResponseWriter, r *http.Request, _c2 pkg.EmptyStruct) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		i.Server.ExternalTypeParam(w, r, _c2)
+	}
+	i.NewHandler(prometheus.Labels{"handler": "ExternalTypeParam"}, http.HandlerFunc(handler))(w, r)
+}
+
+func (i *InstrumentedServer) NoParam(w http.ResponseWriter, r *http.Request) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		i.Server.NoParam(w, r)
+	}
+	i.NewHandler(prometheus.Labels{"handler": "NoParam"}, http.HandlerFunc(handler))(w, r)
+}
+
+func (i *InstrumentedServer) PointerParam(w http.ResponseWriter, r *http.Request, _c2 *string) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		i.Server.PointerParam(w, r, _c2)
+	}
+	i.NewHandler(prometheus.Labels{"handler": "PointerParam"}, http.HandlerFunc(handler))(w, r)
+}
+
+func (i *InstrumentedServer) SliceParam(w http.ResponseWriter, r *http.Request, _c2 []string) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		i.Server.SliceParam(w, r, _c2)
+	}
+	i.NewHandler(prometheus.Labels{"handler": "SliceParam"}, http.HandlerFunc(handler))(w, r)
+}
+
+func (i *InstrumentedServer) StringParam(w http.ResponseWriter, r *http.Request, _c2 string) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		i.Server.StringParam(w, r, _c2)
+	}
+	i.NewHandler(prometheus.Labels{"handler": "StringParam"}, http.HandlerFunc(handler))(w, r)
+}
+
+func (i *InstrumentedServer) TypeParam(w http.ResponseWriter, r *http.Request, _c2 Param) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		i.Server.TypeParam(w, r, _c2)
+	}
+	i.NewHandler(prometheus.Labels{"handler": "TypeParam"}, http.HandlerFunc(handler))(w, r)
+}

--- a/examples/http-handler/http-handler.go
+++ b/examples/http-handler/http-handler.go
@@ -1,0 +1,22 @@
+package httphandler
+
+import (
+	"net/http"
+
+	"github.com/leonnicolas/genstrument/examples/pkg"
+)
+
+//go:generate go run ../../ --file-path http-handler.go --pattern Server --mode handler -o gen.go
+
+type Param struct{}
+
+type Server interface {
+	NoParam(w http.ResponseWriter, r *http.Request)
+	StringParam(w http.ResponseWriter, r *http.Request, id string)
+	TypeParam(w http.ResponseWriter, r *http.Request, params Param)
+	ExternalTypeParam(w http.ResponseWriter, r *http.Request, params pkg.EmptyStruct)
+	PointerParam(w http.ResponseWriter, r *http.Request, id *string)
+	SliceParam(w http.ResponseWriter, r *http.Request, id []string)
+	InvalidParams(id []string)
+	InvalidReturns(w http.ResponseWriter, r *http.Request) error
+}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -46,7 +46,7 @@ func TestLoad(t *testing.T) {
 	})
 }
 
-func TestGenerate(t *testing.T) {
+func TestGenerateBinary(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -57,6 +57,7 @@ func TestGenerate(t *testing.T) {
 		MetricName: "metric_name_total",
 		MetricHelp: "help to the metric",
 		Pattern:    "Interface",
+		Mode:       Binary,
 	}
 
 	err := c.Generate(ctx)
@@ -65,6 +66,38 @@ func TestGenerate(t *testing.T) {
 	}
 
 	f, err := os.ReadFile("../examples/binary/gen.go")
+	if err != nil {
+		t.Error(err)
+	}
+
+	dmp := diffmatchpatch.New()
+
+	diffs := dmp.DiffMain(string(f), string(buf.Bytes()), false)
+	if !bytes.Equal(f, buf.Bytes()) {
+		if len(diffs) > 0 {
+			t.Error(dmp.DiffPrettyText(diffs))
+		}
+	}
+}
+
+func TestGenerateHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	buf := bytes.NewBuffer(nil)
+	c := Config{
+		FilePath: "../examples/http-handler/http-handler.go",
+		Out:      buf,
+		Pattern:  "Server",
+		Mode:     Handler,
+	}
+
+	err := c.Generate(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	f, err := os.ReadFile("../examples/http-handler/gen.go")
 	if err != nil {
 		t.Error(err)
 	}

--- a/generator/templates/binary.tmpl
+++ b/generator/templates/binary.tmpl
@@ -1,11 +1,5 @@
-// This code in auto generated. DO NOT EDIT.
+{{template "head.tmpl" .}}
 
-package {{.Pkg.Name}}
-
-import (
-	{{range .Imports}}"{{.}}"
-	{{end}}
-)
 {{$instrumentedTypeName := .InstrumentedTypeName}}
 {{$typeName := .Name}}
 

--- a/generator/templates/handler.tmpl
+++ b/generator/templates/handler.tmpl
@@ -1,0 +1,25 @@
+{{template "head.tmpl" .}}
+
+{{$instrumentedTypeName := .InstrumentedTypeName}}
+{{$typeName := .Name}}
+
+type {{$instrumentedTypeName}} struct {
+	{{$typeName}}
+	signalhttp.HandlerInstrumenter
+}
+
+func New{{.InstrumentedTypeName}}(impl {{$typeName}}, r prometheus.Registerer) *{{$instrumentedTypeName}} {
+	i := signalhttp.NewHandlerInstrumenter(r, []string{"handler"})
+	return &{{$instrumentedTypeName}}{impl, i}
+}
+
+{{range .Methods}}
+{{if .IsHandler}}
+func (i *{{$instrumentedTypeName}}) {{.Name}}(w http.ResponseWriter, r *http.Request, {{.ParamsWithTypes}}) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		i.{{$typeName}}.{{.Name}}(w, r, {{.ParamsWithoutTypes}})
+	}
+	i.NewHandler(prometheus.Labels{"handler": "{{.Name}}"}, http.HandlerFunc(handler))(w, r)
+}
+{{end}}
+{{end}}

--- a/generator/templates/head.tmpl
+++ b/generator/templates/head.tmpl
@@ -1,0 +1,8 @@
+// This code in auto generated. DO NOT EDIT.
+
+package {{.Pkg.Name}}
+
+import (
+	{{range .Imports}}"{{.}}"
+	{{end}}
+)

--- a/genstrument.go
+++ b/genstrument.go
@@ -19,6 +19,12 @@ var root = &cobra.Command{
 	Long:  "generate code for a provided interface name, that provided an instrumented wrapper around the original interface",
 	RunE: func(cmd *cobra.Command, _ []string) (err error) {
 		c := &generator.Config{}
+		if mode, err := cmd.PersistentFlags().GetString("mode"); err != nil {
+			return err
+		} else {
+			c.Mode = generator.GeneratorMode(mode)
+		}
+
 		c.FilePath, err = cmd.PersistentFlags().GetString("file-path")
 		if err != nil {
 			return err
@@ -81,17 +87,17 @@ func init() {
 	root.PersistentFlags().StringP("file-path", "f", "", "path of the go file that contains the interface to be instrumented")
 	root.MarkPersistentFlagRequired("file-path")
 
-	root.PersistentFlags().String("metric-name", "", "metric name")
-	root.MarkPersistentFlagRequired("metric-name")
+	root.PersistentFlags().String("metric-name", "metric", "metric name")
 
-	root.PersistentFlags().String("metric-help", "", "metric help text")
-	root.MarkPersistentFlagRequired("metric-help")
+	root.PersistentFlags().String("metric-help", "the metric", "metric help text")
 
 	root.PersistentFlags().String("metric-hist-name", "", "name of this histogram")
 
 	root.PersistentFlags().String("metric-hist-help", "", "histogram help text")
 
 	root.PersistentFlags().StringP("out", "o", "-", "where to write the generated file")
+
+	root.PersistentFlags().StringP("mode", "m", "binary", "where to write the generated file")
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/leonnicolas/genstrument
 go 1.20
 
 require (
+	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/sergi/go-diff v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -134,6 +135,7 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -154,6 +156,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a h1:0usWxe5SGXKQovz3p+BiQ81Jy845xSMu2CWKuXsXuUM=
+github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -170,6 +174,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
@@ -182,6 +187,7 @@ github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6T
 github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
 github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
@@ -189,6 +195,7 @@ github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8
 github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
@@ -214,6 +221,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/vektra/mockery/v2 v2.20.0 h1:/tSAo6+PBWktYELzWVzYaQQTVeomPpAzgBc+7nVz6dU=
 github.com/vektra/mockery/v2 v2.20.0/go.mod h1:mI12pwT9jEsg04dL0FnZNVkmEgfLgRfu4za9uJDpaRg=


### PR DESCRIPTION
Add the `--mode` flag to support instrumenting interfaces with
http.Handler like functions as methods. "Like", because they may have
more parameters than `http.ResponseWriter` and `*http.Request`.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
