### PR TITLE
generator: fix imports

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -98,7 +98,12 @@ func (ii *InstrumentedInterface) typeName(t types.Type) (string, *types.TypeName
 func (ii *InstrumentedInterface) Imports() []string {
 	h := make(map[string]struct{})
 	h["github.com/prometheus/client_golang/prometheus"] = struct{}{}
-	h["github.com/prometheus/client_golang/prometheus/promauto"] = struct{}{}
+	switch ii.c.Mode {
+	case Binary:
+		h["github.com/prometheus/client_golang/prometheus/promauto"] = struct{}{}
+	case Handler:
+		h["github.com/metalmatze/signal/server/signalhttp"] = struct{}{}
+	}
 
 	for _, m := range ii.Methods() {
 		l := m.Signature.Params().Len()


### PR DESCRIPTION
Currently, the promauto package that is added to the generated file uses the wrong path. Also, the signalhttp package is not automatically added to the imports. This commit fixes both of these issues.