### PR TITLE
Support interfaces from external packages

### DIFF
--- a/generator/templates/binary.tmpl
+++ b/generator/templates/binary.tmpl
@@ -2,14 +2,15 @@
 
 {{$instrumentedTypeName := .InstrumentedTypeName}}
 {{$typeName := .Name}}
+{{$packagePrefix := .PackagePrefix}}
 
 type {{$instrumentedTypeName}} struct {
-	{{$typeName}}
+	{{$packagePrefix}}{{$typeName}}
 	cv *prometheus.CounterVec
 	hv *prometheus.HistogramVec
 }
 
-func New{{.InstrumentedTypeName}}(impl {{$typeName}}, r prometheus.Registerer) *{{$instrumentedTypeName}} {
+func New{{.InstrumentedTypeName}}(impl {{$packagePrefix}}{{$typeName}}, r prometheus.Registerer) *{{$instrumentedTypeName}} {
 	hv := promauto.With(r).NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "{{.MetricHistName}}",

--- a/generator/templates/handler.tmpl
+++ b/generator/templates/handler.tmpl
@@ -2,13 +2,14 @@
 
 {{$instrumentedTypeName := .InstrumentedTypeName}}
 {{$typeName := .Name}}
+{{$packagePrefix := .PackagePrefix}}
 
 type {{$instrumentedTypeName}} struct {
-	{{$typeName}}
+	{{$packagePrefix}}{{$typeName}}
 	signalhttp.HandlerInstrumenter
 }
 
-func New{{.InstrumentedTypeName}}(impl {{$typeName}}, r prometheus.Registerer) *{{$instrumentedTypeName}} {
+func New{{.InstrumentedTypeName}}(impl {{$packagePrefix}}{{$typeName}}, r prometheus.Registerer) *{{$instrumentedTypeName}} {
 	i := signalhttp.NewHandlerInstrumenter(r, []string{"handler"})
 	return &{{$instrumentedTypeName}}{impl, i}
 }


### PR DESCRIPTION
To generate code for another package than the supplied interface, use
the `--package` flag.
The generated code will be for the specified package. The source
interface should be available (eg. part of the repo tree, vendored or
part of go.mod).

Signed-off-by: leonnicolas <leonloechner@gmx.de>
