### PR TITLE
generator: support oapi client withBody

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.19
-    - run: go test ./...
+    - run: make test
 
   generate:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
         go-version: 1.19
     - name: Generate
       run: |
-        go generate ./...
+        make generate
         git diff --exit-code
 
   build:
@@ -35,4 +35,4 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.19
-    - run: go build
+    - run: make build

--- a/examples/oapi-codegen-client/client.go
+++ b/examples/oapi-codegen-client/client.go
@@ -3,3 +3,5 @@ package oapicodegenclient
 //go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --config oapi-codegen.yaml petstore.yaml
 
 //go:generate go run github.com/leonnicolas/genstrument --file-path oapi.go -p  ClientWithResponsesInterface --metric-help "help to the metric" --metric-name metric_name_total -o gen.go --mode oapi-codegen-client
+
+//go:generate go run github.com/leonnicolas/genstrument --file-path oapi.go -p  ClientInterface --metric-help "help to the metric" --metric-name metric_name_total -o genWithBody.go --mode oapi-codegen-client

--- a/examples/oapi-codegen-client/genWithBody.go
+++ b/examples/oapi-codegen-client/genWithBody.go
@@ -1,0 +1,111 @@
+// This code in auto generated. DO NOT EDIT.
+
+package oapicodegenclient
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type InstrumentedClientInterface struct {
+	ClientInterface
+	cv *prometheus.CounterVec
+	hv *prometheus.HistogramVec
+}
+
+func NewInstrumentedClientInterface(impl ClientInterface, r prometheus.Registerer) *InstrumentedClientInterface {
+	hv := promauto.With(r).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "metric_name_duration_seconds",
+			Help:    "help to the metric",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"method"})
+
+	cv := promauto.With(r).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "metric_name_total",
+			Help: "help to the metric",
+		}, []string{"method", "code"})
+
+	return &InstrumentedClientInterface{
+		ClientInterface: impl,
+		cv:              cv,
+		hv:              hv,
+	}
+}
+
+func (c *InstrumentedClientInterface) AddPet(_c0 context.Context, _c1 NewPet, _c2 ...RequestEditorFn) (*http.Response, error) {
+	t := time.Now()
+	defer func() {
+		c.hv.WithLabelValues("AddPet").Observe(time.Since(t).Seconds())
+	}()
+	res, err := c.ClientInterface.AddPet(_c0, _c1, _c2...)
+	if err != nil {
+		return res, err
+	}
+	c.cv.WithLabelValues("AddPet", fmt.Sprint(res.StatusCode)).Inc()
+
+	return res, err
+}
+
+func (c *InstrumentedClientInterface) AddPetWithBody(_c0 context.Context, _c1 string, _c2 io.Reader, _c3 ...RequestEditorFn) (*http.Response, error) {
+	t := time.Now()
+	defer func() {
+		c.hv.WithLabelValues("AddPetWithBody").Observe(time.Since(t).Seconds())
+	}()
+	res, err := c.ClientInterface.AddPetWithBody(_c0, _c1, _c2, _c3...)
+	if err != nil {
+		return res, err
+	}
+	c.cv.WithLabelValues("AddPetWithBody", fmt.Sprint(res.StatusCode)).Inc()
+
+	return res, err
+}
+
+func (c *InstrumentedClientInterface) DeletePet(_c0 context.Context, _c1 int64, _c2 ...RequestEditorFn) (*http.Response, error) {
+	t := time.Now()
+	defer func() {
+		c.hv.WithLabelValues("DeletePet").Observe(time.Since(t).Seconds())
+	}()
+	res, err := c.ClientInterface.DeletePet(_c0, _c1, _c2...)
+	if err != nil {
+		return res, err
+	}
+	c.cv.WithLabelValues("DeletePet", fmt.Sprint(res.StatusCode)).Inc()
+
+	return res, err
+}
+
+func (c *InstrumentedClientInterface) FindPetByID(_c0 context.Context, _c1 int64, _c2 ...RequestEditorFn) (*http.Response, error) {
+	t := time.Now()
+	defer func() {
+		c.hv.WithLabelValues("FindPetByID").Observe(time.Since(t).Seconds())
+	}()
+	res, err := c.ClientInterface.FindPetByID(_c0, _c1, _c2...)
+	if err != nil {
+		return res, err
+	}
+	c.cv.WithLabelValues("FindPetByID", fmt.Sprint(res.StatusCode)).Inc()
+
+	return res, err
+}
+
+func (c *InstrumentedClientInterface) FindPets(_c0 context.Context, _c1 *FindPetsParams, _c2 ...RequestEditorFn) (*http.Response, error) {
+	t := time.Now()
+	defer func() {
+		c.hv.WithLabelValues("FindPets").Observe(time.Since(t).Seconds())
+	}()
+	res, err := c.ClientInterface.FindPets(_c0, _c1, _c2...)
+	if err != nil {
+		return res, err
+	}
+	c.cv.WithLabelValues("FindPets", fmt.Sprint(res.StatusCode)).Inc()
+
+	return res, err
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -242,6 +242,22 @@ func (m *Method) ResultsWithoutTypes() (str string) {
 	return strings.Join(strs, ",")
 }
 
+func (m *Method) ReturnsHTTPResponse() bool {
+	if m.Signature == nil {
+		return false
+	}
+	r := m.Signature.Results()
+	if r == nil {
+		return false
+	}
+	l := r.Len()
+	if l < 1 {
+		return false
+	}
+	v := r.At(0)
+	return v.Type().String() == "*net/http.Response"
+}
+
 func (m *Method) ResultTypes() (str string) {
 	if m.Signature == nil {
 		return ""

--- a/generator/templates/oapi-codegen-client.tmpl
+++ b/generator/templates/oapi-codegen-client.tmpl
@@ -41,7 +41,7 @@ func (c *{{$instrumentedTypeName}}) {{.Name}}({{.ParamsWithTypes}}) ({{.ResultTy
 	if err != nil {
 		return res, err
 	}
-	c.cv.WithLabelValues("{{.Name}}", fmt.Sprint(res.StatusCode())).Inc()
+	c.cv.WithLabelValues("{{.Name}}", fmt.Sprint(res.StatusCode{{if not .ReturnsHTTPResponse}}(){{end}})).Inc()
 
 	return res, err
 }


### PR DESCRIPTION
Before we could only generate code for the `*WithResonsesInterface`.
With this commit the simple `ClientInterface` can also be instrumented.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
